### PR TITLE
Add multi stage build to upgrade lubssl3 to latest patched version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
+FROM debian:12-slim AS security-patch
+RUN apt-get update && apt-get upgrade -y libssl3 && rm -rf /var/lib/apt/lists/*
+
 FROM gcr.io/distroless/nodejs24-debian12
+
+COPY --from=security-patch /usr/lib/x86_64-linux-gnu/libssl.so.3 /usr/lib/x86_64-linux-gnu/libssl.so.3
+COPY --from=security-patch /usr/lib/x86_64-linux-gnu/libcrypto.so.3 /usr/lib/x86_64-linux-gnu/libcrypto.so.3
 
 WORKDIR /usr/src/app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "tms-microfrontend-template-ssr",
       "version": "0.0.1",
-      "engines": {
-        "node": ">=22.12.0"
-      },
       "dependencies": {
         "@astrojs/check": "^0.9.8",
         "@astrojs/node": "^10.1.0",
@@ -38,6 +35,9 @@
         "prettier": "3.3.3",
         "tsx": "4.21.0",
         "typescript": "5.3.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@astrojs/check": {


### PR DESCRIPTION
The CVEs are in libssl3 from the distroless base image. Since distroless has no package manager, the fix is a multi-stage build that copies the patched library from an updated Debian image.

The Dockerfile now uses a multi-stage build that:

security-patch stage — starts from debian:12-slim, upgrades libssl3 to the latest patched version
Final stage — copies the patched libssl.so.3 and libcrypto.so.3 into the distroless image, overwriting the vulnerable versions
This resolves both CVE-2026-31789 and CVE-2026-34182 without changing the distroless base or adding a package manager to the final image.